### PR TITLE
Add compatibility for PHP 5.4 and 5.5

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -32,7 +32,7 @@ $EM_CONF[$_EXTKEY] = array (
   array (
     'depends' => 
     array (
-      'php' => '5.3.2-5.3.99',
+      'php' => '5.3.2-5.5.99',
       'typo3' => '4.5.0-6.2.999',
     ),
     'conflicts' => 


### PR DESCRIPTION
TYPO3 6.2 supports PHP 5.4 and 5.5.
EXT:robots should also do so, since it attests compatibility with TYPO3 6.2
