### PR TITLE
#3: Make robots compatible with TYPO3 7.6

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,8 +1,12 @@
 <?php
-if (!defined ('TYPO3_MODE')) {
-	die ('Access denied.');
+/**
+ * Pages table: add custom fields
+ *
+ * @link https://docs.typo3.org/typo3cms/TCAReference/
+ */
+if (!defined('TYPO3_MODE')) {
+    die('Access denied.');
 }
-
 $tempColumns = array(
 	'tx_robots_flags' => array(
 		'exclude' => true,
@@ -19,8 +23,10 @@ $tempColumns = array(
 );
 
 
-t3lib_div::loadTCA('pages');
-t3lib_extMgm::addTCAcolumns('pages', $tempColumns, 1);
-t3lib_extMgm::addToAllTCAtypes('pages','tx_robots_flags;;;;1-1-1', '1,2', 'before:TSconfig');
-
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns(
+    'pages', $tempColumns, 1
+);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+    'pages', 'tx_robots_flags;;;;1-1-1', '1,2', 'before:TSconfig'
+);
 ?>

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -32,8 +32,8 @@ $EM_CONF[$_EXTKEY] = array (
   array (
     'depends' => 
     array (
-      'php' => '5.3.2-5.5.99',
-      'typo3' => '4.5.0-6.2.999',
+      'php' => '5.3.2-7.1.99',
+      'typo3' => '6.2.99-7.6.99',
     ),
     'conflicts' => 
     array (


### PR DESCRIPTION
The TCA override configuration directory is usable since TYPO3 6.2,
see https://forge.typo3.org/issues/57942 for more information.